### PR TITLE
collect slide conversion errors before raising

### DIFF
--- a/ppt_workflow/core/outline_to_plan.py
+++ b/ppt_workflow/core/outline_to_plan.py
@@ -253,7 +253,11 @@ class OutlineToPlanConverter:
 
             except ValueError as e:
                 self.errors.append(str(e))
-                raise
+                # Collect errors but continue processing remaining slides
+
+        if self.errors:
+            combined = "\n".join(self.errors)
+            raise ValueError(f"Conversion encountered errors:\n{combined}")
 
         # Build layout strategy with actual indices from ic-template-1
         layout_strategy = {


### PR DESCRIPTION
## Summary
- accumulate slide conversion errors without immediate failure
- raise combined error after processing all slides in `convert`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c79f87e3408321ad7e22e92e5df23e