### PR TITLE
Add basic unit tests for planning and VBA generation

### DIFF
--- a/ppt_workflow/tests/test_outline_to_plan.py
+++ b/ppt_workflow/tests/test_outline_to_plan.py
@@ -1,0 +1,26 @@
+import json
+import unittest
+from pathlib import Path
+
+from ppt_workflow.core.outline_to_plan import OutlineToPlanConverter
+
+
+class TestOutlineToPlanConverter(unittest.TestCase):
+    """Basic tests for OutlineToPlanConverter."""
+
+    def setUp(self):
+        base = Path(__file__).resolve().parent.parent
+        self.outline = base / "examples" / "simple_outline.json"
+        self.analysis = base / "examples" / "template_analysis.json"
+
+    def test_convert_produces_plan(self):
+        """Converting an outline should yield a slide plan with expected slides."""
+        converter = OutlineToPlanConverter(str(self.outline), str(self.analysis))
+        plan = converter.convert()
+
+        self.assertEqual(len(plan["slides"]), 3)
+        self.assertEqual(plan["slides"][0]["selected_layout"]["name"], "Title Slide")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ppt_workflow/tests/test_plan_to_vba.py
+++ b/ppt_workflow/tests/test_plan_to_vba.py
@@ -1,0 +1,68 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from ppt_workflow.core.outline_to_plan import OutlineToPlanConverter
+from ppt_workflow.core.plan_to_vba import PlanToVBAConverter
+
+
+class TestPlanToVBAConverter(unittest.TestCase):
+    """Tests for generating VBA code from a slide plan."""
+
+    def setUp(self):
+        base = Path(__file__).resolve().parent.parent
+        outline = base / "examples" / "simple_outline.json"
+        analysis = base / "examples" / "template_analysis.json"
+        converter = OutlineToPlanConverter(str(outline), str(analysis))
+        self.plan = converter.convert()
+
+    def test_vba_generation_contains_main(self):
+        """Generated VBA should include entry point and active presentation reference."""
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
+            json.dump(self.plan, tmp)
+            tmp_path = tmp.name
+        try:
+            vba_converter = PlanToVBAConverter(tmp_path)
+            code = vba_converter.convert()
+            self.assertIn("Sub Main()", code)
+            self.assertIn("Application.ActivePresentation", code)
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    def test_missing_image_detection(self):
+        """PlanToVBAConverter should record missing image files."""
+        base = Path(__file__).resolve().parent.parent
+        analysis = base / "examples" / "template_analysis.json"
+        outline_data = {
+            "meta": {"title": "Image Test"},
+            "slides": [
+                {
+                    "layout": "Picture with Caption",
+                    "placeholders": {
+                        "Title": "Image Slide",
+                        "Picture": "nonexistent.png",
+                        "Body": "Caption"
+                    }
+                }
+            ]
+        }
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as out_tmp:
+            json.dump(outline_data, out_tmp)
+            outline_path = out_tmp.name
+        try:
+            converter = OutlineToPlanConverter(outline_path, str(analysis))
+            plan = converter.convert()
+            with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as plan_tmp:
+                json.dump(plan, plan_tmp)
+                plan_path = plan_tmp.name
+            vba = PlanToVBAConverter(plan_path)
+            self.assertTrue(vba.missing_images)
+            self.assertIn("nonexistent.png", vba.missing_images[0]["path"])
+        finally:
+            Path(outline_path).unlink(missing_ok=True)
+            Path(plan_path).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add regression tests covering outline-to-plan conversion and VBA code generation
- ensure generated VBA includes main entry point and active presentation reference
- warn when VBA generation encounters missing image files

## Testing
- `python -m unittest discover ppt_workflow/tests`


------
https://chatgpt.com/codex/tasks/task_e_68c7a1e90cf883218d52b74a27454e9e